### PR TITLE
Implement web receipt preview

### DIFF
--- a/app/Http/Controllers/admin/Admin.php
+++ b/app/Http/Controllers/admin/Admin.php
@@ -480,6 +480,23 @@ class Admin extends Controller
         return view('taxfull', compact('config', 'pay', 'order', 'get'));
     }
 
+    public function printReceiptWeb($id)
+    {
+        $get = $_GET;
+
+        $config = Config::first();
+        $pay = Pay::find($id);
+        $paygroup = PayGroup::where('pay_id', $id)->get();
+        $order_id = array();
+        foreach ($paygroup as $rs) {
+            $order_id[] = $rs->order_id;
+        }
+        $order = OrdersDetails::whereIn('order_id', $order_id)
+            ->with('menu', 'option.option')
+            ->get();
+        return view('print_web', compact('config', 'pay', 'order', 'get'));
+    }
+
     public function order_rider()
     {
         $data['function_key'] = 'order_rider';

--- a/resources/views/order.blade.php
+++ b/resources/views/order.blade.php
@@ -218,6 +218,7 @@
                 <iframe src="" id="preview-frame" style="width:100%;height:500px;border:0;"></iframe>
             </div>
             <div class="modal-footer">
+                <button type="button" class="btn btn-success" id="print_web">แสดงหน้าเว็บ</button>
                 <button type="button" class="btn btn-primary" id="confirm-print">ปริ้นใบเสร็จ</button>
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ปิด</button>
             </div>
@@ -640,6 +641,7 @@
         var id = $(this).data('id');
         $('#preview-frame').attr('src', '<?= url('admin/order/printReceipt') ?>/' + id + '?preview=1');
         $('#confirm-print').data('url', '<?= url('admin/order/printReceipt') ?>/' + id);
+        $('#print_web').data('url', '<?= url('admin/order/printReceiptWeb') ?>/' + id);
         $('#modal-preview').modal('show');
     });
 
@@ -654,7 +656,13 @@
         $('#modal-tax-full').modal('hide');
         $('#preview-frame').attr('src', urlPreview);
         $('#confirm-print').data('url', '<?= url('admin/order/printReceiptfull') ?>/' + pay_id + '?name=' + name + '&tel=' + tel + '&tax_id=' + tax_id + '&address=' + address);
+        $('#print_web').data('url', '<?= url('admin/order/printReceiptWeb') ?>/' + pay_id + '?name=' + name + '&tel=' + tel + '&tax_id=' + tax_id + '&address=' + address);
         $('#modal-preview').modal('show');
+    });
+
+    $('#print_web').click(function() {
+        var url = $(this).data('url');
+        $('#preview-frame').attr('src', url);
     });
 
     $('#confirm-print').click(function() {
@@ -666,6 +674,7 @@
     $('#modal-preview').on('hidden.bs.modal', function() {
         $('#preview-frame').attr('src', '');
         $('#confirm-print').data('url', '');
+        $('#print_web').data('url', '');
     });
 </script>
 @endsection

--- a/resources/views/print_web.blade.php
+++ b/resources/views/print_web.blade.php
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ESC/POS Printer</title>
+    <style>
+        body {
+          font-family: Arial, sans-serif;
+          padding: 20px;
+        }
+
+        button {
+          padding: 10px 16px;
+          margin: 8px 0;
+          font-size: 16px;
+          width: 100%;
+        }
+
+        textarea {
+          width: 100%;
+          height: 100px;
+          margin: 8px 0;
+        }
+    </style>
+</head>
+<body>
+<button onclick="sendCommand('STATUS_PRINTER')">Check Printer Status</button>
+<button onclick="sendPrintCommand()">Print Receipt</button>
+<pre id="statusOutput" style="margin-top: 20px;"></pre>
+<script>
+    function getBridge() {
+      if (window.posRegisterInterface) return window.posRegisterInterface;
+      if (window.webkit?.messageHandlers?.posRegisterInterface) return window.webkit.messageHandlers.posRegisterInterface;
+      return null;
+    }
+
+    function sendCommand(command) {
+      const payload = {
+        command: command,
+        payload: []
+      };
+      const bridge = getBridge();
+      if (bridge) {
+        if (bridge.postMessage) bridge.postMessage(JSON.stringify(payload));
+        else if (typeof bridge.sendRequest === "function") bridge.sendRequest(JSON.stringify(payload));
+      } else {
+        alert("JSBridge not available");
+      }
+    }
+
+    function sendPrintCommand() {
+      const payload = {
+        "command": "PRINT_START",
+        "payload": [
+          {
+            "align": "center",
+            "bold": true,
+            "data": "{{ $config->name }}",
+            "size": 2,
+            "type": "text"
+          },
+          {
+            "type": "newline"
+          },
+          {
+            "align": "left",
+            "bold": true,
+            "data": "เลขที่ใบเสร็จ #{{ $pay->payment_number }}",
+            "type": "text"
+          },
+          {
+            "align": "left",
+            "data": "วันที่: {{ $pay->created_at }}",
+            "type": "text"
+          },
+          {
+            "type": "newline"
+          },
+          {
+            "type": "line"
+          },
+          @foreach($order as $rs)
+          {
+            "columns": [
+              {
+                "text": "{{ $rs['menu']->name }}",
+                "width": 60
+              },
+              {
+                "text": "{{ $rs->quantity }}",
+                "width": 10
+              },
+              {
+                "text": "{{ number_format($rs->price, 2) }} ฿",
+                "width": 30
+              }
+            ],
+            "type": "table"
+          },
+          @foreach($rs['option'] as $option)
+          {
+            "align": "left",
+            "data": "+ {{ $option['option']->type }}",
+            "type": "text"
+          },
+          @endforeach
+          {
+            "type": "line"
+          },
+          @endforeach
+          {
+            "type": "newline"
+          },
+          {
+            "bold": true,
+            "size": "2",
+            "type": "line"
+          },
+          {
+            "align": "right",
+            "bold": true,
+            "data": "Total: {{ number_format($pay->total, 2) }} ฿",
+            "size": "1",
+            "type": "text"
+          },
+           {
+            "type": "newline"
+          },
+          {
+            "type": "newline"
+          }
+        ]
+      }
+      const bridge = getBridge();
+      if (bridge) {
+        if (bridge.postMessage) bridge.postMessage(JSON.stringify(payload));
+        else if (typeof bridge.sendRequest === "function") bridge.sendRequest(JSON.stringify(payload));
+      } else {
+        alert("JSBridge not available");
+      }
+    }
+
+    function onPrinterStatusUpdate(connected) {
+      const msg = connected ? "🟢 Printer Connected" : "🔴 Printer Not Connected";
+      document.getElementById("statusOutput").textContent = msg;
+    }
+</script>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -94,6 +94,7 @@ Route::middleware(['role:admin'])->group(function () {
     Route::post('/admin/order/confirm_rider', [Admin::class, 'confirm_rider'])->name('confirm_rider');
     Route::get('/admin/order/printReceipt/{id}', [Admin::class, 'printReceipt'])->name('printReceipt');
     Route::get('/admin/order/printReceiptfull/{id}', [Admin::class, 'printReceiptfull'])->name('printReceiptfull');
+    Route::get('/admin/order/printReceiptWeb/{id}', [Admin::class, 'printReceiptWeb'])->name('printReceiptWeb');
     Route::get('/admin/order_rider', [Admin::class, 'order_rider'])->name('order_rider');
     Route::post('/admin/order/ListOrderRider', [Admin::class, 'ListOrderRider'])->name('ListOrderRider');
     //Cancel


### PR DESCRIPTION
## Summary
- add `printReceiptWeb` route and controller method
- create `print_web` Blade view for web-based receipt printing
- update admin order page to include new **แสดงหน้าเว็บ** button
- handle preview logic for the new button

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e37e623ec8329b9cf531a8d405588