### PR TITLE
Add web receipt preview

### DIFF
--- a/app/Http/Controllers/admin/Admin.php
+++ b/app/Http/Controllers/admin/Admin.php
@@ -480,6 +480,21 @@ class Admin extends Controller
         return view('taxfull', compact('config', 'pay', 'order', 'get'));
     }
 
+    public function printReceiptWeb($id)
+    {
+        $config = Config::first();
+        $pay = Pay::find($id);
+        $paygroup = PayGroup::where('pay_id', $id)->get();
+        $order_id = [];
+        foreach ($paygroup as $rs) {
+            $order_id[] = $rs->order_id;
+        }
+        $order = OrdersDetails::whereIn('order_id', $order_id)
+            ->with('menu', 'option.option')
+            ->get();
+        return view('receipt_web', compact('config', 'pay', 'order'));
+    }
+
     public function order_rider()
     {
         $data['function_key'] = 'order_rider';

--- a/resources/views/order.blade.php
+++ b/resources/views/order.blade.php
@@ -219,6 +219,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-primary" id="confirm-print">ปริ้นใบเสร็จ</button>
+                <button type="button" class="btn btn-info" id="print_web">print_web</button>
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ปิด</button>
             </div>
         </div>
@@ -636,12 +637,13 @@
             }
         });
     });
-    $(document).on('click', '.preview-short', function(e) {
-        var id = $(this).data('id');
-        $('#preview-frame').attr('src', '<?= url('admin/order/printReceipt') ?>/' + id + '?preview=1');
-        $('#confirm-print').data('url', '<?= url('admin/order/printReceipt') ?>/' + id);
-        $('#modal-preview').modal('show');
-    });
+   $(document).on('click', '.preview-short', function(e) {
+       var id = $(this).data('id');
+       $('#preview-frame').attr('src', '<?= url('admin/order/printReceipt') ?>/' + id + '?preview=1');
+       $('#confirm-print').data('url', '<?= url('admin/order/printReceipt') ?>/' + id);
+        $('#print_web').data('url', '<?= url('admin/order/receiptWeb') ?>/' + id);
+       $('#modal-preview').modal('show');
+   });
 
     $(document).on('click', '#preview-tax-full', function(e) {
         e.preventDefault();
@@ -651,21 +653,28 @@
         var tax_id = $('#tax_id').val();
         var address = $('#address').val();
         var urlPreview = '<?= url('admin/order/printReceiptfull') ?>/' + pay_id + '?name=' + name + '&tel=' + tel + '&tax_id=' + tax_id + '&address=' + address + '&preview=1';
-        $('#modal-tax-full').modal('hide');
-        $('#preview-frame').attr('src', urlPreview);
-        $('#confirm-print').data('url', '<?= url('admin/order/printReceiptfull') ?>/' + pay_id + '?name=' + name + '&tel=' + tel + '&tax_id=' + tax_id + '&address=' + address);
-        $('#modal-preview').modal('show');
-    });
+       $('#modal-tax-full').modal('hide');
+       $('#preview-frame').attr('src', urlPreview);
+       $('#confirm-print').data('url', '<?= url('admin/order/printReceiptfull') ?>/' + pay_id + '?name=' + name + '&tel=' + tel + '&tax_id=' + tax_id + '&address=' + address);
+        $('#print_web').data('url', '<?= url('admin/order/receiptWeb') ?>/' + pay_id);
+       $('#modal-preview').modal('show');
+   });
 
-    $('#confirm-print').click(function() {
+   $('#confirm-print').click(function() {
+       var url = $(this).data('url');
+       window.open(url, '_blank');
+       $('#modal-preview').modal('hide');
+   });
+
+    $('#print_web').click(function() {
         var url = $(this).data('url');
         window.open(url, '_blank');
-        $('#modal-preview').modal('hide');
     });
 
-    $('#modal-preview').on('hidden.bs.modal', function() {
-        $('#preview-frame').attr('src', '');
-        $('#confirm-print').data('url', '');
-    });
+   $('#modal-preview').on('hidden.bs.modal', function() {
+       $('#preview-frame').attr('src', '');
+       $('#confirm-print').data('url', '');
+        $('#print_web').data('url', '');
+   });
 </script>
 @endsection

--- a/resources/views/receipt_web.blade.php
+++ b/resources/views/receipt_web.blade.php
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ESC/POS Printer</title>
+    <style>
+        body {
+          font-family: Arial, sans-serif;
+          padding: 20px;
+        }
+
+        button {
+          padding: 10px 16px;
+          margin: 8px 0;
+          font-size: 16px;
+          width: 100%;
+        }
+
+        textarea {
+          width: 100%;
+          height: 100px;
+          margin: 8px 0;
+        }
+    </style>
+</head>
+<body>
+<button onclick="sendCommand('STATUS_PRINTER')">Check Printer Status</button>
+<button onclick="sendPrintCommand()">Print Receipt</button>
+<pre id="statusOutput" style="margin-top: 20px;"></pre>
+<script>
+    function getBridge() {
+      if (window.posRegisterInterface) return window.posRegisterInterface;
+      if (window.webkit?.messageHandlers?.posRegisterInterface) return window.webkit.messageHandlers.posRegisterInterface;
+      return null;
+    }
+
+    function sendCommand(command) {
+      const payload = {
+        command: command,
+        payload: []
+      };
+      const bridge = getBridge();
+      if (bridge) {
+        if (bridge.postMessage) bridge.postMessage(JSON.stringify(payload));
+        else if (typeof bridge.sendRequest === "function") bridge.sendRequest(JSON.stringify(payload));
+      } else {
+        alert("JSBridge not available");
+      }
+    }
+
+    function sendPrintCommand() {
+      const items = @json($order->map(function($rs){
+            $opts = [];
+            foreach($rs['option'] as $op){
+                $opts[] = $op['option']->type;
+            }
+            return [
+                'name' => $rs['menu']->name,
+                'qty' => $rs->quantity,
+                'price' => number_format($rs->price,2),
+                'options' => $opts
+            ];
+        }));
+
+      const lines = [
+        {"align":"center","bold":true,"data":"{{$config->name}}","size":2,"type":"text"},
+        {"type":"newline"},
+        {"align":"left","bold":true,"data":"เลขที่ใบเสร็จ #{{$pay->payment_number}}","type":"text"},
+        {"align":"left","data":"วันที่: {{$pay->created_at}}","type":"text"},
+        {"type":"newline"},
+        {"type":"line"}
+      ];
+      items.forEach(item => {
+        lines.push({"columns":[{"text":item.name,"width":60},{"text":String(item.qty),"width":10},{"text":item.price+" \u0e3f","width":30}],"type":"table"});
+        item.options.forEach(op=>{
+          lines.push({"align":"left","data":"+ "+op,"type":"text"});
+        });
+        lines.push({"type":"line"});
+      });
+      lines.push({"type":"newline"});
+      lines.push({"bold":true,"size":"2","type":"line"});
+      lines.push({"align":"right","bold":true,"data":"Total: {{number_format($pay->total,2)}} \u0e3f","size":"1","type":"text"});
+      lines.push({"type":"newline"});
+      lines.push({"type":"newline"});
+
+      const payload = {"command":"PRINT_START","payload": lines};
+      const bridge = getBridge();
+      if (bridge) {
+        if (bridge.postMessage) bridge.postMessage(JSON.stringify(payload));
+        else if (typeof bridge.sendRequest === "function") bridge.sendRequest(JSON.stringify(payload));
+      } else {
+        alert("JSBridge not available");
+      }
+    }
+
+    function onPrinterStatusUpdate(connected) {
+      const msg = connected ? "🟢 Printer Connected" : "🔴 Printer Not Connected";
+      document.getElementById("statusOutput").textContent = msg;
+    }
+</script>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -94,6 +94,7 @@ Route::middleware(['role:admin'])->group(function () {
     Route::post('/admin/order/confirm_rider', [Admin::class, 'confirm_rider'])->name('confirm_rider');
     Route::get('/admin/order/printReceipt/{id}', [Admin::class, 'printReceipt'])->name('printReceipt');
     Route::get('/admin/order/printReceiptfull/{id}', [Admin::class, 'printReceiptfull'])->name('printReceiptfull');
+    Route::get('/admin/order/receiptWeb/{id}', [Admin::class, 'printReceiptWeb'])->name('printReceiptWeb');
     Route::get('/admin/order_rider', [Admin::class, 'order_rider'])->name('order_rider');
     Route::post('/admin/order/ListOrderRider', [Admin::class, 'ListOrderRider'])->name('ListOrderRider');
     //Cancel


### PR DESCRIPTION
## Summary
- add printReceiptWeb action and route
- create receipt_web view with JS bridge printing
- add print_web button to order preview modal
- update JS to open the web receipt

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e37e623ec8329b9cf531a8d405588